### PR TITLE
Fix for Requirements Missing 'Requests' Pkg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
   version = '1.300',
   install_requires=[
         'xmltodict', 
-        'beautifulsoup4'
+        'beautifulsoup4',
+		'requests'
   ],
   description = 'A Python wrapper for the RCSB Protein Data Bank (PDB) API',
   author = 'William Gilpin',


### PR DESCRIPTION
Kept having trouble installing this and realized why: your setup.py file did not require the 'requests' package. This prevented your package from querying the database. Should be fixed now.

Signed-off-by: Robert Langefeld langrc18@wfu.edu