### PR TITLE
[API Refactor / Update] - Factored out HTTP Methods into separate file, added tests

### DIFF
--- a/pypdb/pypdb.py
+++ b/pypdb/pypdb.py
@@ -29,7 +29,7 @@ import re
 import json
 import warnings
 
-from util import http_requests
+from pypdb.util import http_requests
 
 
 '''

--- a/pypdb/pypdb.py
+++ b/pypdb/pypdb.py
@@ -29,7 +29,7 @@ import re
 import json
 import warnings
 
-from pypdb.util import http_requests
+from util import http_requests
 
 
 '''

--- a/pypdb/util/http_requests.py
+++ b/pypdb/util/http_requests.py
@@ -1,0 +1,62 @@
+"""Utility functions for requesting URLs over HTTP"""
+
+from typing import Optional
+
+import time
+import requests
+import warnings
+
+def request_limited(url: str, rtype: str="GET",
+                    num_attempts: int = 3, sleep_time=0.5, **kwargs
+                    ) -> Optional[requests.models.Response]:
+    """
+    HTML request with rate-limiting base on response code
+
+
+    Parameters
+    ----------
+    url : str
+        The url for the request
+    rtype : str
+        The request type (oneof ["GET", "POST"])
+    num_attempts : int
+        In case of a failed retrieval, the number of attempts to try again
+    sleep_time : int
+        The amount of time to wait between requests, in case of
+        API rate limits
+    **kwargs : dict
+        The keyword arguments to pass to the request
+
+    Returns
+    -------
+
+    response : requests.models.Response
+        The server response object. Only returned if request was successful,
+        otherwise returns None.
+
+    """
+
+    if rtype not in ["GET", "POST"]:
+        warnings.warn("Request type not recognized")
+        return None
+
+    total_attempts = 0
+    while (total_attempts <= num_attempts):
+        if rtype == "GET":
+            response = requests.get(url, **kwargs)
+        elif rtype == "POST":
+            response = requests.post(url, **kwargs)
+
+        if response.status_code == 200:
+            return response
+
+        if response.status_code == 429:
+            curr_sleep = (1 + total_attempts)*sleep_time
+            warnings.warn("Too many requests, waiting " + str(curr_sleep) + " s")
+            time.sleep(curr_sleep)
+        elif 500 <= response.status_code < 600:
+            warnings.warn("Server error encountered. Retrying")
+        total_attempts += 1
+
+    warnings.warn("Too many failures on requests. Exiting...")
+    return None

--- a/pypdb/util/test_http_requests.py
+++ b/pypdb/util/test_http_requests.py
@@ -4,14 +4,7 @@ import unittest
 from unittest import mock
 import warnings
 
-# TODO(ejwilliams): Write generic testing script to allow tests to live with
-# their associated implementations
-
-# Import from local directory
-import sys
-sys.path.insert(0, '../pypdb')
-
-from util import http_requests
+import http_requests
 
 
 class TestHTTPRequests(unittest.TestCase):

--- a/tests/test_http_requests.py
+++ b/tests/test_http_requests.py
@@ -1,0 +1,108 @@
+import time
+import requests
+import unittest
+from unittest import mock
+import warnings
+
+# DO NOT APPROVE: Consider writing generic testing script to change to
+# Google-style tests next to libraries.
+
+# Import from local directory
+import sys
+sys.path.insert(0, '../pypdb')
+
+from util import http_requests
+
+
+class TestStringMethods(unittest.TestCase):
+
+    @mock.patch.object(warnings, "warn", autospec=True)
+    @mock.patch.object(time, "sleep", autospec=True)
+    def test_fails_with_invalid_request(self, mock_sleep, mock_warnings):
+        self.assertIsNone(http_requests.request_limited(url="http://protein_data_bank.com",
+                                                        rtype="MAIL"))
+        mock_warnings.assert_called_once_with(
+            "Request type not recognized"
+        )
+        self.assertEqual(len(mock_sleep.mock_calls), 0)
+
+    @mock.patch.object(requests, "get", autospec=True)
+    @mock.patch.object(time, "sleep", autospec=True)
+    def test_get__first_try_success(self, mock_sleep, mock_get):
+        mock_response = mock.create_autospec(requests.models.Response)
+        mock_response.status_code = 200  # A-OK!
+        mock_get.return_value = mock_response
+
+        self.assertEqual(http_requests.request_limited(url="http://get_your_proteins.com",
+                                                       rtype="GET"),
+                         mock_response)
+        mock_get.assert_called_once_with("http://get_your_proteins.com")
+        self.assertEqual(len(mock_sleep.mock_calls), 0)
+
+    @mock.patch.object(requests, "post", autospec=True)
+    @mock.patch.object(time, "sleep", autospec=True)
+    def test_post__first_try_success(self, mock_sleep, mock_post):
+        mock_response = mock.create_autospec(requests.models.Response)
+        mock_response.status_code = 200  # A-OK!
+        mock_post.return_value = mock_response
+
+        self.assertEqual(http_requests.request_limited(url="http://get_your_proteins.com",
+                                                       rtype="POST"),
+                         mock_response)
+        mock_post.assert_called_once_with("http://get_your_proteins.com")
+        self.assertEqual(len(mock_sleep.mock_calls), 0)
+
+    @mock.patch.object(requests, "get", autospec=True)
+    @mock.patch.object(time, "sleep", autospec=True)
+    def test_get__succeeds_third_try(self, mock_sleep, mock_get):
+        # Busy response
+        mock_busy_response = mock.create_autospec(requests.models.Response)
+        mock_busy_response.status_code = 429
+        # Server Error response
+        mock_error_response = mock.create_autospec(requests.models.Response)
+        mock_error_response.status_code = 504
+        # All good (200)
+        mock_ok_response = mock.create_autospec(requests.models.Response)
+        mock_ok_response.status_code = 200
+
+        # Mocks `requests.get` to return Busy, then Server Error, then OK
+        mock_get.side_effect = [mock_busy_response, mock_error_response,
+                                mock_ok_response]
+
+        self.assertEqual(http_requests.request_limited(url="http://get_your_proteins.com",
+                                                       rtype="GET"),
+                         mock_ok_response)
+        self.assertEqual(len(mock_get.mock_calls), 3)
+        mock_get.assert_called_with("http://get_your_proteins.com")
+        # Should only sleep on being throttled (not server error)
+        self.assertEqual(len(mock_sleep.mock_calls), 1)
+
+    @mock.patch.object(warnings, "warn", autospec=True)
+    @mock.patch.object(requests, "post", autospec=True)
+    @mock.patch.object(time, "sleep", autospec=True)
+    def test_post__repeatedly_fails_return_nothing(self, mock_sleep, mock_post, mock_warn):
+        # Busy response
+        mock_busy_response = mock.create_autospec(requests.models.Response)
+        mock_busy_response.status_code = 429
+        mock_post.return_value = mock_busy_response
+
+        self.assertIsNone(http_requests.request_limited(url="http://protein_data_bank.com",
+                                                        rtype="POST"))
+        mock_warn.assert_called_with(
+            "Too many failures on requests. Exiting..."
+        )
+
+        self.assertEqual(len(mock_post.mock_calls), 4)
+        mock_post.assert_called_with("http://protein_data_bank.com")
+        self.assertEqual(len(mock_sleep.mock_calls), 4)
+
+
+
+
+
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_http_requests.py
+++ b/tests/test_http_requests.py
@@ -4,8 +4,8 @@ import unittest
 from unittest import mock
 import warnings
 
-# DO NOT APPROVE: Consider writing generic testing script to change to
-# Google-style tests next to libraries.
+# TODO(ejwilliams): Write generic testing script to allow tests to live with
+# their associated implementations
 
 # Import from local directory
 import sys
@@ -14,7 +14,7 @@ sys.path.insert(0, '../pypdb')
 from util import http_requests
 
 
-class TestStringMethods(unittest.TestCase):
+class TestHTTPRequests(unittest.TestCase):
 
     @mock.patch.object(warnings, "warn", autospec=True)
     @mock.patch.object(time, "sleep", autospec=True)
@@ -95,13 +95,6 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(len(mock_post.mock_calls), 4)
         mock_post.assert_called_with("http://protein_data_bank.com")
         self.assertEqual(len(mock_sleep.mock_calls), 4)
-
-
-
-
-
-
-
 
 
 if __name__ == '__main__':

--- a/tests/test_pypdb.py
+++ b/tests/test_pypdb.py
@@ -1,22 +1,25 @@
-import unittest 
+import unittest
 
 ## Import from local directory
 import sys
 sys.path.insert(0, '../pypdb')
 from pypdb import *
-  
-class TestSearchFunctions(unittest.TestCase): 
-  
-    # Returns True if it successfully connects to the 
+
+# TODO(ejwilliams): Write generic logic, to execute `test_*.py` files
+# within the pypdb directory (removing need for sys.path hack)
+
+class TestSearchFunctions(unittest.TestCase):
+
+    # Returns True if it successfully connects to the
     # protein data bank
     def test_querying(self):
-        found_pdbs = Query('actin network').search()     
-        self.assertTrue(len(found_pdbs) > 0) 
+        found_pdbs = Query('actin network').search()
+        self.assertTrue(len(found_pdbs) > 0)
         self.assertTrue(type(found_pdbs[0]) == str)
-        
+
         # an error page would be a longer string
         self.assertTrue(len(found_pdbs[0]) < 10)
-        
+
     # def test_blast(self):
     #     found_pdbs = blast_from_sequence(
     #         'MTKIANKYEVIDNVEKLEKALKRLREAQSVYATYTQEQVDKIFFEAAMAANKMRIPLAKMAVE'
@@ -26,16 +29,14 @@ class TestSearchFunctions(unittest.TestCase):
     #         + 'DNGMICASEQSVIVLDGVYKEVKKEFEKRGCYFLNEDETEKVRKTIIINGALNAKIVGQKA'
     #         + 'HTIANLAGFEVPETTKILIGEVTSVDISEEFAHEKLCPVLAMYRAKDFDDALDKAERLVAD'
     #         + 'GGFGHTSSLYIDTVTQKEKLQKFSERMKTCRILVNTPSSQGGIGDLYNFKLAPSL',
-    #         1e-20) 
-    #     self.assertTrue(len(found_pdbs) > 0) 
+    #         1e-20)
+    #     self.assertTrue(len(found_pdbs) > 0)
     #     self.assertTrue(type(found_pdbs[0][0]) == str)
-        
+
     #     # an error page would be a longer string
     #     self.assertTrue(len(found_pdbs[0][0]) < 10)
 
 
-  
-if __name__ == '__main__': 
-    unittest.main() 
-    
-    
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I factored the HTTP methods out of `pypdb.py`, so they can be reused in API implementations.

I also added tests to verify behaviour is as expected, using the `unittest` and `mock` python standard libraries.

Also, apologies for the insignificant whitespace changes; I formatted `pypdb.py` to conform to PEP8 by accident.