### PR TITLE
[Testing/Bugfix] - Fixed pathing issues to allow for testing of PyPDB

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -13,6 +13,7 @@ requirements:
     - python {{ python }}
     - setuptools
     - numpy
+    - pytest
 
   run:
     - python  {{ python }}

--- a/pypdb/conftest.py
+++ b/pypdb/conftest.py
@@ -1,0 +1,1 @@
+# Sentinel file for `pytest` (to allow testing of PyPDB)

--- a/pypdb/pypdb.py
+++ b/pypdb/pypdb.py
@@ -29,7 +29,7 @@ import re
 import json
 import warnings
 
-from util import http_requests
+from pypdb.util import http_requests
 
 
 '''

--- a/pypdb/util/test_http_requests.py
+++ b/pypdb/util/test_http_requests.py
@@ -4,7 +4,7 @@ import unittest
 from unittest import mock
 import warnings
 
-import http_requests
+from pypdb.util import http_requests
 
 
 class TestHTTPRequests(unittest.TestCase):


### PR DESCRIPTION
I think I screwed up last commit with how I was importing various module components.

This commit fixes the imports such that pypdb should be usable again (I think my prior CL broke it due to a `ModuleNotFoundError util`).

I also added a `pytest` conda dependency. To run all tests against the project, just run `pytest` within the root project directory.