### PR TITLE
[RCSB Search: Text Service] - Added full support

### DIFF
--- a/pypdb/clients/search/EXAMPLES.md
+++ b/pypdb/clients/search/EXAMPLES.md
@@ -110,7 +110,7 @@ return_type = ReturnType.ENTRY
 results = perform_search(search_service, search_operator, return_type)
 ```
 
-### Search for entries released only in 2019
+### Search for entries released only in 2019 or later
 ```
 from pypdb.clients.search.search_client import perform_search
 from pypdb.clients.search.search_client import SearchService, ReturnType
@@ -127,6 +127,22 @@ return_type = ReturnType.ENTRY
 
 results = perform_search(search_service, search_operator, return_type)
 ```
+### Search for structures under 4 angstroms of resolution
+```
+from pypdb.clients.search.search_client import perform_search
+from pypdb.clients.search.search_client import SearchService, ReturnType
+from pypdb.clients.search.search_client.operators import text_operators
+
+search_service = search_client.SearchService.TEXT
+search_operator = text_operators.ComparisonOperator(
+           value=4,
+           attribute="rcsb_entry_info.resolution_combined",
+           comparison_type=text_operators.ComparisonType.LESS)
+return_type = search_client.ReturnType.ENTRY
+
+results = perform_search(search_service, search_operator, return_type)
+```
+
 
 ### Search for structures with a given attribute.
 
@@ -156,27 +172,25 @@ from pypdb.clients.search.search_client import SearchService, ReturnType
 from pypdb.clients.search.search_client import QueryNode, QueryGroup
 from pypdb.clients.search.search_client.operators import text_operators
 
-# QueryNode associated with structures published after 2019
-after_2019_service = SearchService.TEXT
-after_2019_operator = text_operators.ComparisonOperator(
-       value="2019-01-01T00:00:00Z",
-       attribute="rcsb_accession_info.initial_release_date",
+# QueryNode associated with structures with under 4 Angstroms of resolution
+under_4A_resolution_operator = text_operators.ComparisonOperator(
+       value=4,
+       attribute="rcsb_entry_info.resolution_combined",
        comparison_type=text_operators.ComparisonType.GREATER)
-after_2019_query_node = QueryNode(after_2019_service, after_2019_operator)
+under_4A_query_node = QueryNode(SearchService.TEXT,
+                                  under_4A_resolution_operator)
 
 # QueryNode associated with entities containing 'Mus musculus' lineage
-is_mus_service = SearchService.TEXT
 is_mus_operator = text_operators.ExactMatchOperator(
             value="Mus musculus",
             attribute="rcsb_entity_source_organism.taxonomy_lineage.name")
-is_mus_query_node = QueryNode(is_mus_service, is_mus_operator)
+is_mus_query_node = QueryNode(SearchService.TEXT, is_mus_operator)
 
 # QueryNode associated with entities containing 'Homo sapiens' lineage
-is_human_service = SearchService.TEXT
 is_human_operator = text_operators.ExactMatchOperator(
             value="Homo sapiens",
             attribute="rcsb_entity_source_organism.taxonomy_lineage.name")
-is_human_query_node = QueryNode(is_human_service, is_human_operator)
+is_human_query_node = QueryNode(SearchService.TEXT, is_human_operator)
 
 # QueryGroup associated with being either human or `Mus musculus`
 is_human_or_mus_group = QueryGroup(
@@ -184,16 +198,16 @@ is_human_or_mus_group = QueryGroup(
     logical_operator = LogicalOperator.OR
 )
 
-# QueryGroup associated with being ((Human OR Mus) AND (Published after 2019))
-is_after_2019_and_human_or_mus_group = QueryGroup(
-    queries = [is_human_or_mus_group, after_2019_query_node],
+# QueryGroup associated with being ((Human OR Mus) AND (Under 4 Angstroms))
+is_under_4A_and_human_or_mus_group = QueryGroup(
+    queries = [is_human_or_mus_group, under_4A_query_node],
     logical_operator = LogicalOperator.AND
 )
 
 return_type = ReturnType.ENTRY
 
 results = perform_search_with_graph(
-query_object=is_after_2019_and_human_or_mus_group,
-                             return_type=return_type)
+  query_object=is_under_4A_and_human_or_mus_group,
+  return_type=return_type)
 print(results) # Huzzah
 ```

--- a/pypdb/clients/search/operators/text_operators.py
+++ b/pypdb/clients/search/operators/text_operators.py
@@ -25,9 +25,9 @@ class ExactMatchOperator:
     """Exact match operator indicates that the input value should match a field
     value exactly (including whitespaces, special characters and case)."""
     attribute: str
-    value: str
+    value: Any
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, Any]:
         return {
             "attribute": self.attribute,
             "operator": "exact_match",
@@ -41,9 +41,9 @@ class InOperator:
     expression. It returns results if any value in a list of input values
     matches. It can be used instead of multiple OR conditions."""
     attribute: str
-    values: List[str]  # List of strings, numbers or dates in string format
+    values: List[Any]  # List of strings, numbers or date strings
 
-    def to_dict(self) -> Dict[str, Union[str, List[str]]]:
+    def to_dict(self) -> Dict[str, Any]:
         return {
             "attribute": self.attribute,
             "operator": "in",
@@ -113,10 +113,10 @@ class ComparisonOperator:
     """
 
     attribute: str
-    value: str
+    value: Any
     comparison_type: ComparisonType
 
-    def to_dict(self) -> Dict[str,str]:
+    def to_dict(self) -> Dict[str,Any]:
         return {
             "attribute": self.attribute,
             "operator": self.comparison_type.value,
@@ -128,8 +128,8 @@ class ComparisonOperator:
 class RangeOperator:
     """Returns results with attributes within range."""
     attribute: str
-    from_value: str
-    to_value: str
+    from_value: Any
+    to_value: Any
     include_lower: bool = True # Default inclusive
     include_upper: bool = True # Default inclusive
 

--- a/pypdb/clients/search/search_client.py
+++ b/pypdb/clients/search/search_client.py
@@ -224,6 +224,10 @@ def perform_search_with_graph(query_object: Union[QueryNode, QueryGroup],
     response = requests.post(url=SEARCH_URL_ENDPOINT,
                              data=json.dumps(rcsb_query_dict))
 
+
+    # If your search queries are failing here, it could be that your attribute
+    # doesn't support the SearchOperator you're using.
+    # See: https://search.rcsb.org/search-attributes.html
     if not response.ok:
         warnings.warn("It appears request failed with:" + response.text)
         response.raise_for_status()

--- a/pypdb/clients/search/search_client.py
+++ b/pypdb/clients/search/search_client.py
@@ -196,12 +196,24 @@ def perform_search_with_graph(query_object: Union[QueryNode, QueryGroup],
                               return_raw_json_dict: bool = False) -> List[str]:
     """Performs specified search using RCSB's search node logic.
 
+    Essentially, this allows you to ask multiple questions in one RCSB query.
+
+    For example, you can ask for structures that satisfy all of the following
+    conditions at once:
+        * Are either from Mus musculus or from Homo sapiens lineage
+        * Are both under 4 angstroms of resolution, and published after 2019
+        * Are labelled as "actin-binding protein" OR
+            contain "actin" AND "calmodulin" in their titles.
+
     See https://search.rcsb.org/index.html#building-search-request under
-    "Terminal node" and "Group node" for details.
+    "Terminal node" and "Group node" for more details.
 
     Args:
         query_object: Fully-specified QueryNode or QueryGroup
             object corresponding to the desired search.
+        return_type: Type of entities to return.
+        return_raw_json_dict: Whether to return raw JSON response.
+            (for example, to analyze the scores of various matches)
 
     Returns:
         List of strings, corresponding to hits in the database. Will be of the

--- a/pypdb/clients/search/search_client.py
+++ b/pypdb/clients/search/search_client.py
@@ -141,7 +141,7 @@ RawJSONDictResponse = Dict[str, Any]
 
 def perform_search(search_service: SearchService,
                    search_operator: SearchOperator,
-                   return_type: ReturnType,
+                   return_type: ReturnType = ReturyType.ENTRY,
                    return_raw_json_dict: bool = False
                    ) -> Union[List[str],
                               RawJSONDictResponse]:
@@ -192,7 +192,7 @@ def perform_search(search_service: SearchService,
 
 
 def perform_search_with_graph(query_object: Union[QueryNode, QueryGroup],
-                              return_type: ReturnType,
+                              return_type: ReturnType = ReturnType.ENTRY,
                               return_raw_json_dict: bool = False) -> List[str]:
     """Performs specified search using RCSB's search node logic.
 

--- a/pypdb/clients/search/search_client_test.py
+++ b/pypdb/clients/search/search_client_test.py
@@ -355,6 +355,107 @@ class TestHTTPRequests(unittest.TestCase):
         self.assertEqual(results,
                          canned_json_return_as_dict)
 
+    @mock.patch.object(requests, "post")
+    def test_query_group_after_2019_and_either_musculus_or_human(self, mock_post):
+        # Creates a mock HTTP response, as wrapped by `requests`
+        canned_json_return_as_dict = {
+            "result_set": [
+                {"identifier": "5JUP"},
+                {"identifier": "5JUS"},
+                {"identifier": "5JUO"}
+            ]
+        }
+        mock_response = mock.create_autospec(requests.Response, instance=True)
+        mock_response.json.return_value = canned_json_return_as_dict
+        mock_post.return_value = mock_response
+
+        search_service_one = search_client.SearchService.TEXT
+        search_operator_one = text_operators.ComparisonOperator(
+               value="2019-01-01T00:00:00Z",
+               attribute="rcsb_accession_info.initial_release_date",
+               comparison_type=text_operators.ComparisonType.GREATER)
+        after_2019_query_node = search_client.QueryNode(
+                                    search_service_one, search_operator_one)
+
+        search_service_two = search_client.SearchService.TEXT
+        search_operator_two = text_operators.ExactMatchOperator(
+                    value="Mus musculus",
+                    attribute="rcsb_entity_source_organism.taxonomy_lineage.name")
+        is_mus_query_node = search_client.QueryNode(
+                                    search_service_two, search_operator_two)
+
+        search_service_three = search_client.SearchService.TEXT
+        search_operator_three = text_operators.ExactMatchOperator(
+                    value="Homo sapiens",
+                    attribute="rcsb_entity_source_organism.taxonomy_lineage.name")
+        is_human_query_node = search_client.QueryNode(
+                                    search_service_three, search_operator_three)
+
+        is_human_or_mus_group = search_client.QueryGroup(
+            queries = [is_mus_query_node, is_human_query_node],
+            logical_operator = search_client.LogicalOperator.OR
+        )
+
+        is_after_2019_and_human_or_mus_group = search_client.QueryGroup(
+            queries = [is_human_or_mus_group, after_2019_query_node],
+            logical_operator = search_client.LogicalOperator.AND
+        )
+
+        return_type = search_client.ReturnType.ENTRY
+
+        results = search_client.perform_search_with_graph(
+        query_object=is_after_2019_and_human_or_mus_group,
+                                     return_type=return_type)
+
+        expected_json_dict = {
+          "query": {
+            "type": "group",
+            "logical_operator": "and",
+            "nodes": [
+
+                {'type': 'group',
+                 'logical_operator': 'or',
+                 'nodes': [
+                    {
+                        'type': 'terminal',
+                        'service': 'text',
+                        'parameters': {
+                            'attribute': 'rcsb_entity_source_organism.taxonomy_lineage.name',
+                            'operator': 'exact_match',
+                            'value': 'Mus musculus'
+                        }
+                    },
+                    {
+                        'type': 'terminal',
+                        'service': 'text',
+                        'parameters': {
+                            'attribute': 'rcsb_entity_source_organism.taxonomy_lineage.name',
+                            'operator': 'exact_match',
+                            'value': 'Homo sapiens'
+                        }
+                    },
+                 ]
+                },
+                {'type': 'terminal',
+                 'service': 'text',
+                 'parameters':
+                    {'attribute': 'rcsb_accession_info.initial_release_date',
+                    'operator': 'greater',
+                    'value': '2019-01-01T00:00:00Z'}
+                }
+            ]
+          },
+          "request_options": {"return_all_hits": True},
+          "return_type": "entry"
+        }
+
+        mock_post.assert_called_once_with(url=search_client.SEARCH_URL_ENDPOINT,
+                                          data=json.dumps(expected_json_dict))
+        self.assertEqual(results,
+                         ["5JUP", "5JUS", "5JUO"])
+
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Added Support for QueryGraph-Based Searches

[The new API](https://search.rcsb.org/index.html#building-search-request) allows for building up search queries based on boolean aggregation of various search query nodes. I did this through implementing `perform_search_through_graph`, within `search_client.py`.

### Example Question

For example, you can ask "I would like structures that are under 4 angstroms, and published after 2019 using CryoEM, and are either Homo sapiens or Mus musculus". 

### Example Syntax for Group Query
(this specific example asks for structures under 4 angstroms that are Homo sapiens or Mus musculus, but you can go as complicated as you like hypothetically).

I added this example to `EXAMPLES.md`.

```python
from pypdb.clients.search.search_client import QueryNode, QueryGroup, perform_search_with_graph
from pypdb.clients.search.search_client import LogicalOperator, ReturnType
from pypdb.clients.search.operators import text_operators

# QueryNode associated with structures with under 4 Angstroms of resolution
under_4A_resolution_operator = text_operators.ComparisonOperator(
       value=4,
       attribute="rcsb_entry_info.resolution_combined",
       comparison_type=text_operators.ComparisonType.GREATER)
under_4A_query_node = QueryNode(SearchService.TEXT,
                                  under_4A_resolution_operator)

# QueryNode associated with entities containing 'Mus musculus' lineage
is_mus_operator = text_operators.ExactMatchOperator(
            value="Mus musculus",
            attribute="rcsb_entity_source_organism.taxonomy_lineage.name")
is_mus_query_node = QueryNode(SearchService.TEXT, is_mus_operator)

# QueryNode associated with entities containing 'Homo sapiens' lineage
is_human_operator = text_operators.ExactMatchOperator(
            value="Homo sapiens",
            attribute="rcsb_entity_source_organism.taxonomy_lineage.name")
is_human_query_node = QueryNode(SearchService.TEXT, is_human_operator)

# QueryGroup associated with being either human or `Mus musculus`
is_human_or_mus_group = QueryGroup(
    queries = [is_mus_query_node, is_human_query_node],
    logical_operator = LogicalOperator.OR
)

# QueryGroup associated with being ((Human OR Mus) AND (Under 4 Angstroms))
is_under_4A_and_human_or_mus_group = QueryGroup(
    queries = [is_human_or_mus_group, under_4A_query_node],
    logical_operator = LogicalOperator.AND
)

return_type = ReturnType.ENTRY

results = perform_search_with_graph(
  query_object=is_under_4A_and_human_or_mus_group,
  return_type=return_type)
print(results) # Huzzah
```

## Bugfixes

Fixed bug in which you couldn't correctly query for structure resolution.
(due to needing to support integer QueryNode values).

## Tests + `mypy`

All tests pass, and all files pass `mypy` typing analysis.
(Done using: ` mypy --namespace-packages pypdb/clients/search/search_client_test.py` or another path)