### PR TITLE
[RCSB Search API] - Added support for `NOT_EQUAL` comparison type

### DIFF
--- a/pypdb/clients/search/operators/text_operators.py
+++ b/pypdb/clients/search/operators/text_operators.py
@@ -90,6 +90,7 @@ class ComparisonType(Enum):
     GREATER = "greater"
     GREATER_OR_EQUAL = "greater_or_equal"
     EQUAL = "equal"
+    NOT_EQUAL = "not_equal"
     LESS_OR_EQUAL = "less_or_equal"
     LESS = "less"
 
@@ -117,12 +118,20 @@ class ComparisonOperator:
     comparison_type: ComparisonType
 
     def to_dict(self) -> Dict[str,Any]:
-        return {
-            "attribute": self.attribute,
-            "operator": self.comparison_type.value,
-            "value": self.value
-        }
+        if self.comparison_type is ComparisonType.NOT_EQUAL:
+            param_dict = {
+                "operator": "equals",
+                "negation": True
+            }
+        else:
+            param_dict = {
+                "operator": self.comparison_type.value
+            }
 
+        param_dict["attribute"] = self.attribute
+        param_dict["value"] = self.value
+
+        return param_dict
 
 @dataclass
 class RangeOperator:

--- a/pypdb/clients/search/operators/text_operators_test.py
+++ b/pypdb/clients/search/operators/text_operators_test.py
@@ -1,0 +1,24 @@
+"""Tests for RCSB Text Search Service Operators
+(admittedly, a lot is tested in `search_client_test.py` too)
+"""
+
+import unittest
+
+from pypdb.clients.search.operators import text_operators
+
+class TestHTTPRequests(unittest.TestCase):
+
+    def test_not_equals_operator(self):
+        not_equals_operator = text_operators.ComparisonOperator(
+            attribute = "struct.favourite_marvel_movie",
+            value = "Thor: Ragnarok",
+            comparison_type = text_operators.ComparisonType.NOT_EQUAL
+        )
+
+        self.assertEqual(not_equals_operator.to_dict(),
+                         {
+                            "attribute": "struct.favourite_marvel_movie",
+                            "value": "Thor: Ragnarok",
+                            "operator": "equals",
+                            "negation": True
+                         })

--- a/pypdb/clients/search/search_client.py
+++ b/pypdb/clients/search/search_client.py
@@ -141,7 +141,7 @@ RawJSONDictResponse = Dict[str, Any]
 
 def perform_search(search_service: SearchService,
                    search_operator: SearchOperator,
-                   return_type: ReturnType = ReturyType.ENTRY,
+                   return_type: ReturnType = ReturnType.ENTRY,
                    return_raw_json_dict: bool = False
                    ) -> Union[List[str],
                               RawJSONDictResponse]:

--- a/pypdb/clients/search/search_client_test.py
+++ b/pypdb/clients/search/search_client_test.py
@@ -248,8 +248,8 @@ class TestHTTPRequests(unittest.TestCase):
             {'type': 'terminal',
              'service': 'text',
              'parameters':
-                {'attribute': 'rcsb_accession_info.initial_release_date',
-                'operator': 'greater',
+                {'operator': 'greater',
+                'attribute': 'rcsb_accession_info.initial_release_date',
                 'value': '2019-01-01T00:00:00Z'}
             },
         'request_options': {'return_all_hits': True},
@@ -439,8 +439,8 @@ class TestHTTPRequests(unittest.TestCase):
                 {'type': 'terminal',
                  'service': 'text',
                  'parameters':
-                    {'attribute': 'rcsb_accession_info.initial_release_date',
-                    'operator': 'greater',
+                    {'operator': 'greater',
+                    'attribute': 'rcsb_accession_info.initial_release_date',
                     'value': '2019-01-01T00:00:00Z'}
                 }
             ]
@@ -486,8 +486,8 @@ class TestHTTPRequests(unittest.TestCase):
             "type": "terminal",
             "service": "text",
             "parameters": {
-              "attribute": "rcsb_entry_info.resolution_combined",
               "operator": "less",
+              "attribute": "rcsb_entry_info.resolution_combined",
               "value": 4
             }
           },


### PR DESCRIPTION
## Feature Description

I implemented a `NOT_EQUAL` `ComparisonType` for the `ComparisonOperator` within the Text Search Service.

This contributes incrementally towards [Issue 18](https://github.com/williamgilpin/pypdb/issues/18).

## Rationale

I know I said earlier I would support negation for the RCSB Search API ([it's briefly mentioned here](http://search.rcsb.org/#field-queries)) but I cannot think of a good reason it is useful beyond wanting to query something being 'not equal' to some other value.

So, to keep the API wrapper "sparking joy" (=> not loaded with unnecessary arguments), I implemented a `NOT_EQUAL` comparison type that should do the trick just fine. So, downstream users need not know what this negation thing is.

## Tests + `mypy`

All tests pass using `pytest`, all files pass `mypy` inpection using `mypy --namespace-packages path/to/file.py`.


