### PR TITLE
Implemented Sequence and Structure RCSB Search Services

### DIFF
--- a/pypdb/clients/search/EXAMPLES.md
+++ b/pypdb/clients/search/EXAMPLES.md
@@ -162,12 +162,12 @@ return_type = ReturnType.ENTRY
 results = perform_search(search_service, search_operator, return_type)
 ```
 
-### Search for structures matching the given protein sequence
+### Search for top 100 structures matching the given protein sequence, by date
 
 (this sequence matches the SARS-CoV-2 NSP3 macrodomain)
 
 ```
-from pypdb.clients.search.search_client import perform_search
+from pypdb.clients.search.search_client import perform_search, RequestOptions
 from pypdb.clients.search.search_client import SearchService, ReturnType
 from pypdb.clients.search.operators.sequence_operators import SequenceOperator
 from pypdb.clients.search.operators.sequence_operators import SequenceType
@@ -183,7 +183,14 @@ results = perform_search(
           "IHSLRVCVDTVRTNVYLAVFDKNLYDKLVSSFL"),
         identity_cutoff=0.99,
         evalue_cutoff=1000
-      )
+      ),
+    request_options=RequestOptions(
+        result_start_index=0,
+        num_results=100,
+        sort_by="rcsb_accession_info.initial_release_date",
+        desc=False
+      ),
+    return_with_scores=True
 )
 ```
 

--- a/pypdb/clients/search/EXAMPLES.md
+++ b/pypdb/clients/search/EXAMPLES.md
@@ -242,3 +242,42 @@ results = perform_search_with_graph(
   query_object=is_under_4A_and_human_or_mus_group,
   return_type=return_type)
 ```
+
+## Search for Calcium-Bound Calmodulin Structures
+
+Note that "1CLL" corresponds to a Calmodulin structure bound to Ca2+.
+
+Also, searching for `rcsb_chem_comp_container_identifiers.comp_id` with
+an exact match to `"CA"` yields only structures in complex with Ca2+
+(filtering out structures in complex with other metals like strontium).
+
+```
+from pypdb.clients.search.search_client import perform_search_with_graph
+from pypdb.clients.search.search_client import SearchService, ReturnType
+from pypdb.clients.search.search_client import QueryNode, QueryGroup, LogicalOperator
+from pypdb.clients.search.operators import text_operators, structure_operators
+
+is_similar_to_1CLL = QueryNode(
+  search_service=SearchService.STRUCTURE,
+  search_operator=structure_operators.StructureOperator(
+      pdb_entry_id="1CLL",
+      assembly_id=1,
+      search_mode=structure_operators.StructureSearchMode.STRICT_SHAPE_MATCH
+  )
+)
+
+is_in_complex_with_calcium = QueryNode(
+  search_service=SearchService.TEXT,
+  search_operator=text_operators.ExactMatchOperator(
+    attribute="rcsb_chem_comp_container_identifiers.comp_id",
+    value="CA"
+  )
+)
+
+results = perform_search_with_graph(
+  query_object=QueryGroup(
+    logical_operator=LogicalOperator.AND,
+    queries=[is_similar_to_1CLL, is_in_complex_with_calcium]
+  ),
+  return_type=ReturnType.ENTRY
+)

--- a/pypdb/clients/search/EXAMPLES.md
+++ b/pypdb/clients/search/EXAMPLES.md
@@ -162,6 +162,31 @@ return_type = ReturnType.ENTRY
 results = perform_search(search_service, search_operator, return_type)
 ```
 
+### Search for structures matching the given protein sequence
+
+(this sequence matches the SARS-CoV-2 NSP3 macrodomain)
+
+```
+from pypdb.clients.search.search_client import perform_search
+from pypdb.clients.search.search_client import SearchService, ReturnType
+from pypdb.clients.search.operators.sequence_operators import SequenceOperator
+from pypdb.clients.search.operators.sequence_operators import SequenceType
+
+results = perform_search(
+    search_service=SearchService.SEQUENCE,
+    return_type=ReturnType.ENTRY,
+    search_operator=SequenceOperator(
+        sequence_type=SequenceType.PROTEIN,
+        sequence=(
+          "SMVNSFSGYLKLTDNVYIKNADIVEEAKKVKPTVVVNAANVYLKHGGGVAGALNKATNNAMQVESDDY"
+          "IATNGPLKVGGSCVLSGHNLAKHCLHVVGPNVNKGEDIQLLKSAYENFNQHEVLLAPLLSAGIFGADP"
+          "IHSLRVCVDTVRTNVYLAVFDKNLYDKLVSSFL"),
+        identity_cutoff=0.99,
+        evalue_cutoff=1000
+      )
+)
+```
+
 ## `perform_search_with_graph` Example
 
 ### Search for 'Mus musculus' or 'Homo sapiens' structures after 2019

--- a/pypdb/clients/search/operators/sequence_operators.py
+++ b/pypdb/clients/search/operators/sequence_operators.py
@@ -30,15 +30,3 @@ class SequenceOperator:
             "target": self.sequence_type.value,
             "value": self.sequence
         }
-
-# An object of type `SequenceSearchOperator` can be any of the following classes:
-SequenceSearchOperator = Union[
-    SequenceOperator
-]
-
-# List of all SequenceSearchOperator-associated classes, for backwards compatability
-# in terms of checking SearchOperator validity
-# (please change this when you change the `Union` definition)
-SEQUENCE_SEARCH_OPERATORS = [
-    SequenceOperator
-]

--- a/pypdb/clients/search/operators/sequence_operators.py
+++ b/pypdb/clients/search/operators/sequence_operators.py
@@ -18,10 +18,10 @@ class SequenceOperator:
     sequence_type: SequenceType
     # Maximum E Value allowed for results
     # (see: https://www.ncbi.nlm.nih.gov/BLAST/tutorial/Altschul-1.html)
-    evalue_cutoff: float
+    evalue_cutoff: float = 100
     # Minimum identity cutoff allowed for results
     # (see: https://www.ncbi.nlm.nih.gov/books/NBK62051/def-item/identity/)
-    identity_cutoff: float
+    identity_cutoff: float = 0.95
 
     def _to_dict(self) -> Dict[str, Any]:
         return {

--- a/pypdb/clients/search/operators/sequence_operators.py
+++ b/pypdb/clients/search/operators/sequence_operators.py
@@ -1,0 +1,44 @@
+"""Search operator for searching sequences using MMseqs2 (BLAST-like)."""
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Union
+
+class SequenceType(Enum):
+    """Type of sequence being searched."""
+    DNA = "pdb_dna_sequence"
+    RNA = "pdb_rna_sequence"
+    PROTEIN= "pdb_protein_sequence"
+
+
+@dataclass
+class SequenceOperator:
+    """Default search operator; searches across available fields search,
+    and returns a hit if a match happens in any field."""
+    sequence: str
+    sequence_type: SequenceType
+    # Maximum E Value allowed for results
+    # (see: https://www.ncbi.nlm.nih.gov/BLAST/tutorial/Altschul-1.html)
+    evalue_cutoff: float
+    # Minimum identity cutoff allowed for results
+    # (see: https://www.ncbi.nlm.nih.gov/books/NBK62051/def-item/identity/)
+    identity_cutoff: float
+
+    def _to_dict(self) -> Dict[str, Any]:
+        return {
+            "evalue_cutoff": self.evalue_cutoff,
+            "identity_cutoff": self.identity_cutoff,
+            "target": self.sequence_type.value,
+            "value": self.sequence
+        }
+
+# An object of type `SequenceSearchOperator` can be any of the following classes:
+SequenceSearchOperator = Union[
+    SequenceOperator
+]
+
+# List of all SequenceSearchOperator-associated classes, for backwards compatability
+# in terms of checking SearchOperator validity
+# (please change this when you change the `Union` definition)
+SEQUENCE_SEARCH_OPERATORS = [
+    SequenceOperator
+]

--- a/pypdb/clients/search/operators/sequence_operators_test.py
+++ b/pypdb/clients/search/operators/sequence_operators_test.py
@@ -1,0 +1,27 @@
+"""Tests for RCSB Text Search Service Operators
+(admittedly, a lot is tested in `search_client_test.py` too)
+"""
+
+import unittest
+
+from pypdb.clients.search.operators import sequence_operators
+
+class TestSequenceOperators(unittest.TestCase):
+
+    def test_sequence_operator(self):
+        search_operator = sequence_operators.SequenceOperator(
+            sequence="AUGAUUCGGCGCUAAAAAAAA",
+            sequence_type = sequence_operators.SequenceType.RNA,
+            evalue_cutoff=100,
+            identity_cutoff=0.95
+        )
+
+        self.assertEqual(
+            search_operator._to_dict(),
+            {
+                "evalue_cutoff": 100,
+                "identity_cutoff": 0.95,
+                "target": "pdb_rna_sequence",
+                "value": "AUGAUUCGGCGCUAAAAAAAA",
+            }
+        )

--- a/pypdb/clients/search/operators/structure_operators.py
+++ b/pypdb/clients/search/operators/structure_operators.py
@@ -1,0 +1,35 @@
+"""Operators associated with RCSB structural search."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict
+
+class StructureSearchMode(Enum):
+    """Mode to search structures with. See:
+    https://github.com/biocryst/biozernike/
+    """
+    STRICT_SHAPE_MATCH = "strict_shape_match"
+    RELAXED_SHAPE_MATCH = "relaxed_shape_match"
+
+@dataclass
+class StructureOperator:
+    """Operator to perform 3D Structural search using:
+    https://github.com/biocryst/biozernike/
+
+    Will return similar 3D structures using default search options.
+    """
+    # Entry and Assembly # for the chainstructure you want to use for search.
+    # (results will show other PDB entities with similiar 3D Structures)
+    pdb_entry_id: str
+    assembly_id: int = 1
+    # Structure search mode
+    search_mode: StructureSearchMode = StructureSearchMode.STRICT_SHAPE_MATCH
+
+    def _to_dict(self) -> Dict[str, Any]:
+        return {
+            "value": {
+                "entry_id": self.pdb_entry_id,
+                "assembly_id": str(self.assembly_id)
+            },
+            "operator": self.search_mode.value
+        }

--- a/pypdb/clients/search/operators/structure_operators_test.py
+++ b/pypdb/clients/search/operators/structure_operators_test.py
@@ -1,0 +1,38 @@
+"""Tests for Structural searches against RCSB Search API."""
+
+import unittest
+
+from pypdb.clients.search.operators import structure_operators
+
+class TestStructureOperators(unittest.TestCase):
+
+    def test_not_equals_operator(self):
+        structure_operator = structure_operators.StructureOperator(
+            pdb_entry_id="HK97",
+            assembly_id=4,
+            search_mode=structure_operators.StructureSearchMode.STRICT_SHAPE_MATCH
+        )
+
+        self.assertEqual(structure_operator._to_dict(),
+                         {
+                            "value": {
+                                "entry_id": "HK97",
+                                "assembly_id": "4"
+                            },
+                            "operator": "strict_shape_match"
+                         })
+
+        structure_operator_two = structure_operators.StructureOperator(
+            pdb_entry_id="CP77",
+            assembly_id=7,
+            search_mode=structure_operators.StructureSearchMode.RELAXED_SHAPE_MATCH
+        )
+
+        self.assertEqual(structure_operator_two._to_dict(),
+                         {
+                            "value": {
+                                "entry_id": "CP77",
+                                "assembly_id": "7"
+                            },
+                            "operator": "relaxed_shape_match"
+                         })

--- a/pypdb/clients/search/operators/text_operators.py
+++ b/pypdb/clients/search/operators/text_operators.py
@@ -15,7 +15,7 @@ class DefaultOperator:
     and returns a hit if a match happens in any field."""
     value: str
 
-    def to_dict(self) -> Dict[str, str]:
+    def _to_dict(self) -> Dict[str, str]:
         return {
             "value": self.value
         }
@@ -27,7 +27,7 @@ class ExactMatchOperator:
     attribute: str
     value: Any
 
-    def to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> Dict[str, Any]:
         return {
             "attribute": self.attribute,
             "operator": "exact_match",
@@ -43,7 +43,7 @@ class InOperator:
     attribute: str
     values: List[Any]  # List of strings, numbers or date strings
 
-    def to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> Dict[str, Any]:
         return {
             "attribute": self.attribute,
             "operator": "in",
@@ -61,7 +61,7 @@ class ContainsWordsOperator:
     attribute: str
     value: str
 
-    def to_dict(self) -> Dict[str,str]:
+    def _to_dict(self) -> Dict[str,str]:
         return {
             "attribute": self.attribute,
             "operator": "contains_words",
@@ -79,7 +79,7 @@ class ContainsPhraseOperator:
     attribute: str
     value: str
 
-    def to_dict(self) -> Dict[str,str]:
+    def _to_dict(self) -> Dict[str,str]:
         return {
             "attribute": self.attribute,
             "operator": "contains_phrase",
@@ -117,7 +117,7 @@ class ComparisonOperator:
     value: Any
     comparison_type: ComparisonType
 
-    def to_dict(self) -> Dict[str,Any]:
+    def _to_dict(self) -> Dict[str,Any]:
         if self.comparison_type is ComparisonType.NOT_EQUAL:
             param_dict = {
                 "operator": "equals",
@@ -142,7 +142,7 @@ class RangeOperator:
     include_lower: bool = True # Default inclusive
     include_upper: bool = True # Default inclusive
 
-    def to_dict(self) -> Dict[str,Any]:
+    def _to_dict(self) -> Dict[str,Any]:
         return {
         "operator": "range",
         "attribute": self.attribute,
@@ -158,7 +158,7 @@ class RangeOperator:
 class ExistsOperator:
     attribute: str
 
-    def to_dict(self) -> Dict[str,str]:
+    def _to_dict(self) -> Dict[str,str]:
         return {
             "operator": "exists",
             "attribute": self.attribute

--- a/pypdb/clients/search/operators/text_operators_test.py
+++ b/pypdb/clients/search/operators/text_operators_test.py
@@ -6,7 +6,7 @@ import unittest
 
 from pypdb.clients.search.operators import text_operators
 
-class TestHTTPRequests(unittest.TestCase):
+class TestTextOperators(unittest.TestCase):
 
     def test_not_equals_operator(self):
         not_equals_operator = text_operators.ComparisonOperator(

--- a/pypdb/clients/search/operators/text_operators_test.py
+++ b/pypdb/clients/search/operators/text_operators_test.py
@@ -15,7 +15,7 @@ class TestHTTPRequests(unittest.TestCase):
             comparison_type = text_operators.ComparisonType.NOT_EQUAL
         )
 
-        self.assertEqual(not_equals_operator.to_dict(),
+        self.assertEqual(not_equals_operator._to_dict(),
                          {
                             "attribute": "struct.favourite_marvel_movie",
                             "value": "Thor: Ragnarok",

--- a/pypdb/clients/search/search_client.py
+++ b/pypdb/clients/search/search_client.py
@@ -67,7 +67,7 @@ class QueryNode:
     def _check_operator_is_in_appropriate_set(
                 self,
                 search_operator: SearchOperator,
-                appropriate_operator_list: List[SearchOperator],
+                appropriate_operator_list: List[Any],
                 search_service: SearchService,
                 operator_file: str) -> None:
         """Raises Exception if an inappropriate search is attempted."""

--- a/pypdb/clients/search/search_client.py
+++ b/pypdb/clients/search/search_client.py
@@ -18,7 +18,8 @@ import warnings
 from pypdb.clients.search.operators import text_operators
 from pypdb.clients.search.operators import sequence_operators
 from pypdb.clients.search.operators.text_operators import TextSearchOperator
-from pypdb.clients.search.operators.sequence_operators import SequenceSearchOperator
+from pypdb.clients.search.operators.sequence_operators import SequenceOperator
+from pypdb.clients.search.operators.structure_operators import StructureOperator
 
 SEARCH_URL_ENDPOINT: str = "https://search.rcsb.org/rcsbsearch/v1/query"
 
@@ -46,7 +47,8 @@ class LogicalOperator(Enum):
 # see: https://search.rcsb.org/index.html#search-services
 SearchOperator = Union[
     TextSearchOperator,
-    SequenceSearchOperator]
+    SequenceOperator,
+    StructureOperator]
 
 
 @dataclass
@@ -71,7 +73,8 @@ class QueryNode:
         those queries hit RCSB's Search servers."""
 
         if self.search_service not in [SearchService.TEXT,
-                                       SearchService.SEQUENCE]:
+                                       SearchService.SEQUENCE,
+                                       SearchService.STRUCTURE]:
             raise NotImplementedError(
                 "This service isn't yet implemented in the RCSB 2.0 API "
                 "(but watch this space)")
@@ -81,8 +84,11 @@ class QueryNode:
             appropriate_operator_list = text_operators.TEXT_SEARCH_OPERATORS # type: ignore
             operator_file="pypdb/clients/search/operators/text_operators.py"
         elif self.search_service is SearchService.SEQUENCE:
-            appropriate_operator_list = sequence_operators.SEQUENCE_SEARCH_OPERATORS # type: ignore
+            appropriate_operator_list = [SequenceOperator] # type: ignore
             operator_file="pypdb/clients/search/operators/sequence_operators.py"
+        elif self.search_service is SearchService.STRUCTURE:
+            appropriate_operator_list = [StructureOperator] # type: ignore
+            operator_file="pypdb/clients/search/operators/structure_operators.py"
         else:
             # Default to search being OK if there's no validation for
             # this operator defined yet

--- a/pypdb/clients/search/search_client_test.py
+++ b/pypdb/clients/search/search_client_test.py
@@ -1,11 +1,12 @@
 """Tests for RCSB Search API Python wrapper."""
 import json
+import pytest
 import requests
 import unittest
 from unittest import mock
 
 from pypdb.clients.search import search_client
-from pypdb.clients.search.operators import text_operators
+from pypdb.clients.search.operators import sequence_operators, text_operators
 
 class TestHTTPRequests(unittest.TestCase):
 
@@ -499,6 +500,65 @@ class TestHTTPRequests(unittest.TestCase):
                                           data=json.dumps(expected_json_dict))
         self.assertEqual(results,
                          canned_json_return_as_dict)
+
+    @mock.patch.object(requests, "post")
+    def test_sequence_operator_search(self,
+                                                 mock_post):
+        # Creates a mock HTTP response, as wrapped by `requests`
+        canned_json_return_as_dict = {
+            "result_set": [
+                {"identifier": "5JUP"},
+                {"identifier": "5JUS"},
+                {"identifier": "5JUO"}
+            ]
+        }
+        mock_response = mock.create_autospec(requests.Response, instance=True)
+        mock_response.json.return_value = canned_json_return_as_dict
+        mock_post.return_value = mock_response
+
+        results = search_client.perform_search(
+            search_service=search_client.SearchService.SEQUENCE,
+            search_operator=sequence_operators.SequenceOperator(
+                sequence="ATGAGGTAA",
+                sequence_type=sequence_operators.SequenceType.DNA,
+                evalue_cutoff=100,
+                identity_cutoff=0.90
+            ),
+            return_type=search_client.ReturnType.ENTRY)
+
+
+
+        expected_json_dict = {
+        'query':
+            {'type': 'terminal',
+             'service': 'sequence',
+             'parameters':
+                {
+                'evalue_cutoff': 100,
+                'identity_cutoff': 0.90,
+                'target': 'pdb_dna_sequence',
+                'value': 'ATGAGGTAA'
+                }
+            },
+        'request_options': {'return_all_hits': True},
+        'return_type': 'entry'}
+
+        mock_post.assert_called_once_with(url=search_client.SEARCH_URL_ENDPOINT,
+                                          data=json.dumps(expected_json_dict))
+        self.assertEqual(results,
+                         ["5JUP", "5JUS", "5JUO"])
+
+    def test_inappropriate_operator_raises_exception(self):
+        with pytest.raises(search_client.InappropriateSearchOperatorException):
+            search_client.perform_search(
+                search_service=search_client.SearchService.TEXT,
+                search_operator=sequence_operators.SequenceOperator(
+                    sequence="ATGAGGTAA",
+                    sequence_type=sequence_operators.SequenceType.DNA,
+                    evalue_cutoff=100,
+                    identity_cutoff=0.90
+                ),
+                return_type=search_client.ReturnType.ENTRY)
 
 
 if __name__ == '__main__':

--- a/pypdb/clients/search/search_client_test.py
+++ b/pypdb/clients/search/search_client_test.py
@@ -560,6 +560,30 @@ class TestHTTPRequests(unittest.TestCase):
                 ),
                 return_type=search_client.ReturnType.ENTRY)
 
+    def test_request_options_to_dict(self):
+        request_options = search_client.RequestOptions(
+            result_start_index = 42,
+            num_results = 8675309,
+            sort_by="fake.rcsb.attribute",
+            desc=False
+        )
+
+        self.assertEqual(
+            request_options._to_dict(),
+            {
+                "pager": {
+                    "start": 42,
+                    "rows": 8675309
+                },
+                "sort": [
+                    {
+                        "sort_by": "fake.rcsb.attribute",
+                        "direction": "asc"
+                    }
+                ]
+            }
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Implemented Features

1. Searching by sequence (BLAST-like)
2. Returning scores with results
3. Specifying pagination and sorting options using "request_options"
4. Implemented Structural Search using Biozernecke.

This should close out #18 and #26.

## Example Usage of Sequence
```python
from pypdb.clients.search.search_client import perform_search, RequestOptions
from pypdb.clients.search.search_client import SearchService, ReturnType
from pypdb.clients.search.operators.sequence_operators import SequenceOperator
from pypdb.clients.search.operators.sequence_operators import SequenceType

results = perform_search(
    search_service=SearchService.SEQUENCE,
    return_type=ReturnType.ENTRY,
    search_operator=SequenceOperator(
        sequence_type=SequenceType.PROTEIN,
        sequence=(
          "SMVNSFSGYLKLTDNVYIKNADIVEEAKKVKPTVVVNAANVYLKHGGGVAGALNKATNNAMQVESDDY"
          "IATNGPLKVGGSCVLSGHNLAKHCLHVVGPNVNKGEDIQLLKSAYENFNQHEVLLAPLLSAGIFGADP"
          "IHSLRVCVDTVRTNVYLAVFDKNLYDKLVSSFL"),
        identity_cutoff=0.99,
        evalue_cutoff=1000
      ),
    return_with_scores=True,
    request_options = RequestOptions(
        result_start_index=42,
        num_results=100,
        sort_by="score",
        desc=True)
)
```

This yields:
```python
[ScoredResult(entity_id='5RV6', score=1.0), ScoredResult(entity_id='5RUT', score=1.0), ScoredResult(entity_id='5RV5', score=1.0), ScoredResult(entity_id='5RV8', score=1.0), ScoredResult(entity_id='5RUW', score=1.0), ScoredResult(entity_id='5RV7', score=1.0), ScoredResult(entity_id='5RUV', score=1.0), ScoredResult(entity_id='5RUI', score=1.0), ScoredResult(entity_id='7KQO', score=1.0), ScoredResult(entity_id='5RUH', score=1.0), ScoredResult(entity_id='7KQP', score=1.0), ScoredResult(entity_id='5RUK', score=1.0),
...
etc.
...
```

## Example Usage of Structure

Note that "1CLL" corresponds to a Calmodulin structure bound to Ca2+.

Also, searching for `rcsb_chem_comp_container_identifiers.comp_id` with
an exact match to `"CA"` yields only structures in complex with Ca2+
(filtering out structures in complex with other metals like strontium).

```python
from pypdb.clients.search.search_client import perform_search_with_graph
from pypdb.clients.search.search_client import SearchService, ReturnType
from pypdb.clients.search.search_client import QueryNode, QueryGroup, LogicalOperator
from pypdb.clients.search.operators import text_operators, structure_operators

is_similar_to_1CLL = QueryNode(
  search_service=SearchService.STRUCTURE,
  search_operator=structure_operators.StructureOperator(
      pdb_entry_id="1CLL",
      assembly_id=1,
      search_mode=structure_operators.StructureSearchMode.STRICT_SHAPE_MATCH
  )
)

is_in_complex_with_calcium = QueryNode(
  search_service=SearchService.TEXT,
  search_operator=text_operators.ExactMatchOperator(
    attribute="rcsb_chem_comp_container_identifiers.comp_id",
    value="CA"
  )
)

results = perform_search_with_graph(
  query_object=QueryGroup(
    logical_operator=LogicalOperator.AND,
    queries=[is_similar_to_1CLL, is_in_complex_with_calcium]
  ),
  return_type=ReturnType.ENTRY
)
```

## Testing 
Tests passed using `pytest`

Typing passed using `mypy --namespace-packages pypdb/path/to/file.py`

## Miscellaneous Notes

Apologies for the large commit! In future I'll be better about using branches.

Happy holidays!