### PR TITLE
Implemented FASTA fetching, autoresolving sequence type for `SequenceOperator` searches

### DIFF
--- a/pypdb/clients/fasta/fasta_client.py
+++ b/pypdb/clients/fasta/fasta_client.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import re
 import requests
 from typing import Dict, List
+import warnings
 
 FASTA_BASE_URL = "https://www.rcsb.org/fasta/entry/"
 

--- a/pypdb/clients/fasta/fasta_client.py
+++ b/pypdb/clients/fasta/fasta_client.py
@@ -25,12 +25,12 @@ class FastaSequence:
     # (e.g. `5RU3_1|Chains A,B|Non-structural protein 3|Severe acute respiratory syndrome coronavirus 2 (2697049)`)
     fasta_header: str
 
-def _parse_fasta_text_to_dict(raw_fasta_text: str) -> Dict[PolymerEntity, FastaSequence]:
+def _parse_fasta_text_to_list(raw_fasta_text: str) -> List[FastaSequence]:
     """Parses raw FASTA response into easy-to-use dict representation."""
     # Gets list of FASTA chunks (one per sequence)
     fasta_sequence_chunks = raw_fasta_text.strip().split(">")[1:]
 
-    fasta_dict = {}
+    fasta_list = []
     for fasta_sequence_chunk in fasta_sequence_chunks:
         chunk_lines = fasta_sequence_chunk.split("\n")
         fasta_header = chunk_lines[0]
@@ -41,15 +41,15 @@ def _parse_fasta_text_to_dict(raw_fasta_text: str) -> Dict[PolymerEntity, FastaS
         # Derives associated chains from header
         chains = re.sub("Chains? ", "", header_segments[1]).split(",")
 
-        fasta_dict[entity_id] = FastaSequence(
+        fasta_list.append(FastaSequence(
             entity_id=entity_id,
             chains=chains,
             sequence=fasta_sequence,
             fasta_header=fasta_header
-        )
-    return fasta_dict
+        ))
+    return fasta_list
 
-def get_fasta_from_rcsb_entry(rcsb_id: str) -> Dict[PolymerEntity, FastaSequence]:
+def get_fasta_from_rcsb_entry(rcsb_id: str) -> List[FastaSequence]:
     """Fetches FASTA sequence associated with PDB structure from RCSB.
 
     Args:
@@ -67,4 +67,4 @@ def get_fasta_from_rcsb_entry(rcsb_id: str) -> Dict[PolymerEntity, FastaSequence
         warnings.warn("It appears request failed with:" + response.text)
         response.raise_for_status()
 
-    return _parse_fasta_text_to_dict(response.text)
+    return _parse_fasta_text_to_list(response.text)

--- a/pypdb/clients/fasta/fasta_client.py
+++ b/pypdb/clients/fasta/fasta_client.py
@@ -1,0 +1,69 @@
+"""Client to fetch FASTA files associated with structures from RCSB."""
+
+from dataclasses import dataclass
+import re
+import requests
+from typing import Dict, List
+
+FASTA_BASE_URL = "https://www.rcsb.org/fasta/entry/"
+
+# Fasta Sequences are uniquely identified by a polymeric entity ID that looks
+# like `${ENTRY_ID}_{SEQUENCE_NUMBER}` (e.g. `5JUP_1` or `6TML_10`)
+PolymerEntity = str # Defines type-alias (Polymer entity IDs are strings)
+
+@dataclass
+class FastaSequence:
+    """Class containing data for one FASTA sequence (one of many in a file)."""
+    # Polymeric entity ID uniquely identifying this sequence
+    entity_id: PolymerEntity # e.g. `"5RU3_1"`
+    # Chains associated with this sequence
+    chains: List[str] # e.g. `["A", "B"]`
+    # Sequence associated with this entity
+    sequence: str
+    # Un-processed FASTA header for a sequence
+    # (e.g. `5RU3_1|Chains A,B|Non-structural protein 3|Severe acute respiratory syndrome coronavirus 2 (2697049)`)
+    fasta_header: str
+
+def _parse_fasta_text_to_dict(raw_fasta_text: str) -> Dict[PolymerEntity, FastaSequence]:
+    """Parses raw FASTA response into easy-to-use dict representation."""
+    # Gets list of FASTA chunks (one per sequence)
+    fasta_sequence_chunks = raw_fasta_text.strip().split(">")[1:]
+
+    fasta_dict = {}
+    for fasta_sequence_chunk in fasta_sequence_chunks:
+        chunk_lines = fasta_sequence_chunk.split("\n")
+        fasta_header = chunk_lines[0]
+        fasta_sequence = "".join(chunk_lines[1:])
+
+        header_segments = fasta_header.split("|")
+        entity_id = header_segments[0]
+        # Derives associated chains from header
+        chains = re.sub("Chains? ", "", header_segments[1]).split(",")
+
+        fasta_dict[entity_id] = FastaSequence(
+            entity_id=entity_id,
+            chains=chains,
+            sequence=fasta_sequence,
+            fasta_header=fasta_header
+        )
+    return fasta_dict
+
+def get_fasta_from_rcsb_entry(rcsb_id: str) -> Dict[PolymerEntity, FastaSequence]:
+    """Fetches FASTA sequence associated with PDB structure from RCSB.
+
+    Args:
+      rcsb_id: RCSB accession code of the structure of interest. E.g. `"5RU3"`
+
+    Returns:
+      Dictionary containing FASTA result, from polymer entity id to the
+      `FastaSequence` object associated with that entity.
+    """
+
+    print("Querying RCSB for the '{}' FASTA file.".format(rcsb_id))
+    response = requests.get(FASTA_BASE_URL+rcsb_id)
+
+    if not response.ok:
+        warnings.warn("It appears request failed with:" + response.text)
+        response.raise_for_status()
+
+    return _parse_fasta_text_to_dict(response.text)

--- a/pypdb/clients/fasta/fasta_client_test.py
+++ b/pypdb/clients/fasta/fasta_client_test.py
@@ -9,7 +9,7 @@ from pypdb.clients.fasta import fasta_client
 class TestFastaLogic(unittest.TestCase):
 
     @mock.patch.object(requests, "get")
-    @mock.patch.object(fasta_client, "_parse_fasta_text_to_dict")
+    @mock.patch.object(fasta_client, "_parse_fasta_text_to_list")
     def test_get_fasta_file(self,
                             mock_parse_fasta,
                             mock_get):
@@ -18,7 +18,7 @@ class TestFastaLogic(unittest.TestCase):
         mock_response.text = "fake_fasta_response"
         mock_get.return_value = mock_response
 
-        result_dict = fasta_client.get_fasta_from_rcsb_entry("6TML")
+        fasta_client.get_fasta_from_rcsb_entry("6TML")
         mock_get.assert_called_once_with("https://www.rcsb.org/fasta/entry/6TML")
         mock_parse_fasta.assert_called_once_with("fake_fasta_response")
 
@@ -32,25 +32,25 @@ MPSSSSEDAQGGNRFECVSNSTSPRRKNATKDEAACLQPRRSAVSGPREDVLCIR
 >6TML_32|Chains H1,H2,H3,H4|subunit c|Toxoplasma gondii (strain ATCC 50853 / GT1) (507601)
 MFFSRLSLSALKAAPAREAL"""
 
-        self.assertEqual(fasta_client._parse_fasta_text_to_dict(test_fasta_raw_text),
-        {
-            "6TML_1": fasta_client.FastaSequence(
+        self.assertEqual(fasta_client._parse_fasta_text_to_list(test_fasta_raw_text),
+        [
+            fasta_client.FastaSequence(
                 entity_id="6TML_1",
                 chains=["Q7", "Q8", "Q9", "q7", "q8", "q9"],
                 sequence="MVRNQRYPASPVQEIFLPEPVPFVQFDQTAPSPNSPPAPLPSPSLSQCEEQKDRYR",
                 fasta_header="6TML_1|Chains Q7,Q8,Q9,q7,q8,q9|ATPTG11|Toxoplasma gondii (strain ATCC 50853 / GT1) (507601)"
             ),
-            "6TML_2": fasta_client.FastaSequence(
+            fasta_client.FastaSequence(
                 entity_id="6TML_2",
                 chains=["i9"],
                 sequence="MPSSSSEDAQGGNRFECVSNSTSPRRKNATKDEAACLQPRRSAVSGPREDVLCIR",
                 fasta_header="6TML_2|Chain i9|ATPTG7|Toxoplasma gondii (strain ATCC 50853 / GT1) (507601)"
             ),
-            "6TML_32": fasta_client.FastaSequence(
+            fasta_client.FastaSequence(
                 entity_id="6TML_32",
                 chains=["H1","H2","H3","H4"],
                 sequence="MFFSRLSLSALKAAPAREAL",
                 fasta_header="6TML_32|Chains H1,H2,H3,H4|subunit c|Toxoplasma gondii (strain ATCC 50853 / GT1) (507601)"
             )
-        }
+        ]
         )

--- a/pypdb/clients/fasta/fasta_client_test.py
+++ b/pypdb/clients/fasta/fasta_client_test.py
@@ -1,0 +1,56 @@
+"""Tests for RCSB FASTA fetching logic."""
+import pytest
+import requests
+import unittest
+from unittest import mock
+
+from pypdb.clients.fasta import fasta_client
+
+class TestFastaLogic(unittest.TestCase):
+
+    @mock.patch.object(requests, "get")
+    @mock.patch.object(fasta_client, "_parse_fasta_text_to_dict")
+    def test_get_fasta_file(self,
+                            mock_parse_fasta,
+                            mock_get):
+        mock_response = mock.Mock()
+        mock_response.ok = True
+        mock_response.text = "fake_fasta_response"
+        mock_get.return_value = mock_response
+
+        result_dict = fasta_client.get_fasta_from_rcsb_entry("6TML")
+        mock_get.assert_called_once_with("https://www.rcsb.org/fasta/entry/6TML")
+        mock_parse_fasta.assert_called_once_with("fake_fasta_response")
+
+    def test_parse_fasta_file(self):
+
+        test_fasta_raw_text = """
+>6TML_1|Chains Q7,Q8,Q9,q7,q8,q9|ATPTG11|Toxoplasma gondii (strain ATCC 50853 / GT1) (507601)
+MVRNQRYPASPVQEIFLPEPVPFVQFDQTAPSPNSPPAPLPSPSLSQCEEQKDRYR
+>6TML_2|Chain i9|ATPTG7|Toxoplasma gondii (strain ATCC 50853 / GT1) (507601)
+MPSSSSEDAQGGNRFECVSNSTSPRRKNATKDEAACLQPRRSAVSGPREDVLCIR
+>6TML_32|Chains H1,H2,H3,H4|subunit c|Toxoplasma gondii (strain ATCC 50853 / GT1) (507601)
+MFFSRLSLSALKAAPAREAL"""
+
+        self.assertEqual(fasta_client._parse_fasta_text_to_dict(test_fasta_raw_text),
+        {
+            "6TML_1": fasta_client.FastaSequence(
+                entity_id="6TML_1",
+                chains=["Q7", "Q8", "Q9", "q7", "q8", "q9"],
+                sequence="MVRNQRYPASPVQEIFLPEPVPFVQFDQTAPSPNSPPAPLPSPSLSQCEEQKDRYR",
+                fasta_header="6TML_1|Chains Q7,Q8,Q9,q7,q8,q9|ATPTG11|Toxoplasma gondii (strain ATCC 50853 / GT1) (507601)"
+            ),
+            "6TML_2": fasta_client.FastaSequence(
+                entity_id="6TML_2",
+                chains=["i9"],
+                sequence="MPSSSSEDAQGGNRFECVSNSTSPRRKNATKDEAACLQPRRSAVSGPREDVLCIR",
+                fasta_header="6TML_2|Chain i9|ATPTG7|Toxoplasma gondii (strain ATCC 50853 / GT1) (507601)"
+            ),
+            "6TML_32": fasta_client.FastaSequence(
+                entity_id="6TML_32",
+                chains=["H1","H2","H3","H4"],
+                sequence="MFFSRLSLSALKAAPAREAL",
+                fasta_header="6TML_32|Chains H1,H2,H3,H4|subunit c|Toxoplasma gondii (strain ATCC 50853 / GT1) (507601)"
+            )
+        }
+        )

--- a/pypdb/clients/search/EXAMPLES.md
+++ b/pypdb/clients/search/EXAMPLES.md
@@ -176,7 +176,7 @@ results = perform_search(
     search_service=SearchService.SEQUENCE,
     return_type=ReturnType.ENTRY,
     search_operator=SequenceOperator(
-        sequence_type=SequenceType.PROTEIN,
+        sequence_type=SequenceType.PROTEIN, # if not explicitly specified, this will autoresolve
         sequence=(
           "SMVNSFSGYLKLTDNVYIKNADIVEEAKKVKPTVVVNAANVYLKHGGGVAGALNKATNNAMQVESDDY"
           "IATNGPLKVGGSCVLSGHNLAKHCLHVVGPNVNKGEDIQLLKSAYENFNQHEVLLAPLLSAGIFGADP"
@@ -189,6 +189,29 @@ results = perform_search(
         num_results=100,
         sort_by="rcsb_accession_info.initial_release_date",
         desc=False
+      ),
+    return_with_scores=True
+)
+```
+
+### Search for structures that match the sequence of an existing RCSB entry
+```
+from pypdb.clients.fasta.fasta_client import get_fasta_from_rcsb_entry
+from pypdb.clients.search.search_client import perform_search
+from pypdb.clients.search.search_client import SearchService, ReturnType
+from pypdb.clients.search.operators.sequence_operators import SequenceOperator
+
+# Fetches the first sequence in the "6TML" fasta file
+fasta_sequence = get_fasta_from_rcsb_entry("6TML")["6TML_1"].sequence
+
+# Performs sequence search ('BLAST'-like) using the FASTA sequence
+results = perform_search(
+    search_service=SearchService.SEQUENCE,
+    return_type=ReturnType.ENTRY,
+    search_operator=SequenceOperator(
+        sequence=fasta_sequence,
+        identity_cutoff=0.99,
+        evalue_cutoff=1000
       ),
     return_with_scores=True
 )

--- a/pypdb/clients/search/EXAMPLES.md
+++ b/pypdb/clients/search/EXAMPLES.md
@@ -202,7 +202,7 @@ from pypdb.clients.search.search_client import SearchService, ReturnType
 from pypdb.clients.search.operators.sequence_operators import SequenceOperator
 
 # Fetches the first sequence in the "6TML" fasta file
-fasta_sequence = get_fasta_from_rcsb_entry("6TML")["6TML_1"].sequence
+fasta_sequence = get_fasta_from_rcsb_entry("6TML")[0].sequence
 
 # Performs sequence search ('BLAST'-like) using the FASTA sequence
 results = perform_search(

--- a/pypdb/clients/search/operators/sequence_operators.py
+++ b/pypdb/clients/search/operators/sequence_operators.py
@@ -58,6 +58,6 @@ class SequenceOperator:
         return {
             "evalue_cutoff": self.evalue_cutoff,
             "identity_cutoff": self.identity_cutoff,
-            "target": self.sequence_type.value,
+            "target": self.sequence_type.value, # type: ignore
             "value": self.sequence
         }

--- a/pypdb/clients/search/operators/sequence_operators.py
+++ b/pypdb/clients/search/operators/sequence_operators.py
@@ -1,7 +1,7 @@
 """Search operator for searching sequences using MMseqs2 (BLAST-like)."""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 class SequenceType(Enum):
     """Type of sequence being searched."""
@@ -9,19 +9,50 @@ class SequenceType(Enum):
     RNA = "pdb_rna_sequence"
     PROTEIN= "pdb_protein_sequence"
 
+class CannotAutoresolveSequenceTypeError(Exception):
+    """Raised when a sequence is ambiguous as to its `SequenceType`."""
+
 
 @dataclass
 class SequenceOperator:
     """Default search operator; searches across available fields search,
     and returns a hit if a match happens in any field."""
     sequence: str
-    sequence_type: SequenceType
+     # If the sequence type is not specified, tries to autoresolve the type from
+     # the sequence itself
+    sequence_type: Optional[SequenceType] = None
     # Maximum E Value allowed for results
     # (see: https://www.ncbi.nlm.nih.gov/BLAST/tutorial/Altschul-1.html)
     evalue_cutoff: float = 100
     # Minimum identity cutoff allowed for results
     # (see: https://www.ncbi.nlm.nih.gov/books/NBK62051/def-item/identity/)
     identity_cutoff: float = 0.95
+
+    def __post_init__(self):
+        if self.sequence_type is None:
+            self._autoresolve_sequence_type()
+
+    def _autoresolve_sequence_type(self):
+        unique_letters = set(list(self.sequence))
+
+        dna_letter_set = set(["A", "T", "C", "G"])
+        rna_letter_set = set(["A", "U", "C", "G"])
+        protein_letter_set = set(list("ABCDEFGHIKLMNPQRSTVWXYZ"))
+        protein_fingerprint_set = set(list("BDEFHIKLMNPQRSVWXYZ"))
+        if unique_letters.issubset(dna_letter_set) and "T" in unique_letters:
+            self.sequence_type = SequenceType.DNA
+        elif unique_letters.issubset(rna_letter_set) and "U" in unique_letters:
+            self.sequence_type = SequenceType.RNA
+        elif (unique_letters.issubset(protein_letter_set) and
+              protein_fingerprint_set & unique_letters):
+            self.sequence_type = SequenceType.PROTEIN
+        else:
+            raise CannotAutoresolveSequenceTypeError(
+                "Sequence is ambiguous as to its SequenceType: `{}`".format(
+                    self.sequence
+                )
+            )
+
 
     def _to_dict(self) -> Dict[str, Any]:
         return {

--- a/pypdb/clients/search/operators/sequence_operators_test.py
+++ b/pypdb/clients/search/operators/sequence_operators_test.py
@@ -2,6 +2,7 @@
 (admittedly, a lot is tested in `search_client_test.py` too)
 """
 
+import pytest
 import unittest
 
 from pypdb.clients.search.operators import sequence_operators
@@ -25,3 +26,19 @@ class TestSequenceOperators(unittest.TestCase):
                 "value": "AUGAUUCGGCGCUAAAAAAAA",
             }
         )
+
+    def test_autoresolve_sequence_type(self):
+        self.assertEqual(
+            sequence_operators.SequenceOperator("ATGGGGTAA").sequence_type,
+            sequence_operators.SequenceType.DNA
+        )
+        self.assertEqual(
+            sequence_operators.SequenceOperator("AUGGGGCCCUAA").sequence_type,
+            sequence_operators.SequenceType.RNA
+        )
+        self.assertEqual(
+            sequence_operators.SequenceOperator("MAETREGGQSGAAS").sequence_type,
+            sequence_operators.SequenceType.PROTEIN
+        )
+        with pytest.raises(sequence_operators.CannotAutoresolveSequenceTypeError):
+            sequence_operators.SequenceOperator("AAAAAAAA")

--- a/pypdb/pypdb.py
+++ b/pypdb/pypdb.py
@@ -670,7 +670,7 @@ def get_pdb_file(pdb_id, filetype='pdb', compression=False):
 #     out = to_dict(out)
 #     return remove_at_sign(out['sequenceCluster'])
 
-def get_blast(pdb_id, chain_id='A'):
+def get_blast(pdb_id, chain_id='A', identity_cutoff=0.99):
     """
     ---
     WARNING: this function is deprecated and slated to be deleted due to RCSB
@@ -689,6 +689,8 @@ def get_blast(pdb_id, chain_id='A'):
 
     chain_id : string
         A single character designating the chain ID of interest
+    identity_cutoff: float
+        Identity % at which to cut off results.
 
 
     Returns
@@ -724,7 +726,7 @@ def get_blast(pdb_id, chain_id='A'):
             search_service=search_client.SearchService.SEQUENCE,
             search_operator=sequence_operators.SequenceOperator(
                 sequence=valid_sequence,
-                identity_cutoff=0.99,
+                identity_cutoff=identity_cutoff,
                 evalue_cutoff=1000
             )))
 


### PR DESCRIPTION
## Changes

* Implemented FASTA fetching logic from RCSB endpoint
* Added autoresolving of sequence for sequence searches (to make searching from FASTA files pain-free)

This effectively reimplements the `get_blast` functionality with the new API.
I also actually reimplemented `get_blast` with a deprecation warning.

Hypothetically, this should solve #26 

## Example Usage

Let's say I want to find any structures that are similar in sequence to the first polymer sequence in 6TML's FASTA file.
I would do so using the following code:

```python
from pypdb.clients.fasta.fasta_client import get_fasta_from_rcsb_entry
from pypdb.clients.search.search_client import perform_search
from pypdb.clients.search.search_client import SearchService, ReturnType
from pypdb.clients.search.operators.sequence_operators import SequenceOperator

# Fetches FASTA results from RCSB, as a list of `FastaSequence` objects.
fasta_sequence_list = get_fasta_from_rcsb_entry("6TML")
# Let's arbitrarily pick the first element in the list to search with
sequence_of_interest = fasta_sequence_list[0].sequence

# Performs sequence search ('BLAST'-like) using the FASTA sequence
results = perform_search(
    search_service=SearchService.SEQUENCE,
    return_type=ReturnType.ENTRY,
    search_operator=SequenceOperator(
        sequence=sequence_of_interest,
        identity_cutoff=0.99,
        evalue_cutoff=1000
        # note that the search SequenceType is autoresolved (this fails with ambiguous sequences like "AAAAA")
      ),
    return_with_scores=True
)

results
>>> [ScoredResult(entity_id='6TMK', score=1.0), ScoredResult(entity_id='6TML', score=1.0), ScoredResult(entity_id='6TMJ', score=1.0), ScoredResult(entity_id='6TMG', score=1.0)]
```

## Tests + `mypy`

Tests pass with `pytest`.
Typechecking passes with `mypy --namespace-packages pypdb/path/to/file.py` for all files changed.