### PR TITLE
Fixes small error in comparions types

### DIFF
--- a/pypdb/clients/search/operators/text_operators.py
+++ b/pypdb/clients/search/operators/text_operators.py
@@ -90,7 +90,7 @@ class ContainsPhraseOperator:
 class ComparisonType(Enum):
     GREATER = "greater"
     GREATER_OR_EQUAL = "greater_or_equal"
-    EQUAL = "equal"
+    EQUAL = "equals"
     NOT_EQUAL = "not_equal"
     LESS_OR_EQUAL = "less_or_equal"
     LESS = "less"


### PR DESCRIPTION
PDB expects 'equals', not 'equal'. In the workaround to provide not_equal, you were handing it over correctly already. :)

Thanks for the great work!