### PR TITLE
Added verbose bools to optionally suppress printing output to screen

### DIFF
--- a/pypdb/clients/fasta/fasta_client.py
+++ b/pypdb/clients/fasta/fasta_client.py
@@ -51,18 +51,21 @@ def _parse_fasta_text_to_list(raw_fasta_text: str) -> List[FastaSequence]:
     return fasta_list
 
 
-def get_fasta_from_rcsb_entry(rcsb_id: str) -> List[FastaSequence]:
+def get_fasta_from_rcsb_entry(rcsb_id: str,
+                              verbose: bool = True) -> List[FastaSequence]:
     """Fetches FASTA sequence associated with PDB structure from RCSB.
 
     Args:
       rcsb_id: RCSB accession code of the structure of interest. E.g. `"5RU3"`
+      verbose: Whether to print search query information (default: True)
 
     Returns:
       Dictionary containing FASTA result, from polymer entity id to the
       `FastaSequence` object associated with that entity.
     """
 
-    print("Querying RCSB for the '{}' FASTA file.".format(rcsb_id))
+    if verbose:
+        print("Querying RCSB for the '{}' FASTA file.".format(rcsb_id))
     response = requests.get(FASTA_BASE_URL + rcsb_id)
 
     if not response.ok:

--- a/pypdb/clients/search/search_client.py
+++ b/pypdb/clients/search/search_client.py
@@ -197,7 +197,8 @@ def perform_search_with_graph(
     return_type: ReturnType = ReturnType.ENTRY,
     request_options: Optional[RequestOptions] = None,
     return_with_scores: bool = False,
-    return_raw_json_dict: bool = False
+    return_raw_json_dict: bool = False,
+    verbose: bool = True,
 ) -> Union[List[str], RawJSONDictResponse, List[ScoredResult]]:
     """Performs specified search using RCSB's search node logic.
 
@@ -222,6 +223,7 @@ def perform_search_with_graph(
             get the top X hits that are similar to a certain protein sequence.
         return_raw_json_dict: Whether to return raw JSON response.
             (for example, to analyze the scores of various matches)
+        verbose: Whether to print search query information (default: True)
 
     Returns:
         List of strings, corresponding to hits in the database. Will be of the
@@ -247,8 +249,9 @@ def perform_search_with_graph(
         "return_type": return_type.value
     }
 
-    print("Querying RCSB Search using the following parameters:\n %s \n" %
-          json.dumps(rcsb_query_dict))
+    if verbose:
+        print("Querying RCSB Search using the following parameters:\n %s \n" %
+              json.dumps(rcsb_query_dict))
 
     response = requests.post(url=SEARCH_URL_ENDPOINT,
                              data=json.dumps(rcsb_query_dict))


### PR DESCRIPTION
First off, thank you for the great API! An issue I have noticed is using the programme with significant searches, the output produced by printing the search query and `.fasta` sequence search has been filling my slurm (task manager for supercomputers) logs (and making them very large files) and it would be nice to provide the user an option to toggle output off.

The docstring for the two affected functions has been updated, this is my first pull request so if there is anything I haven't done please let me know and I will make changes if this branch is acceptable.