### PR TITLE
Irems updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 ###Temporary Files created by text editor###
 *~
+.vscode
+.vscode/
 
 ### Remove DS STORE
 *.DS_Store
@@ -71,6 +73,3 @@ target/
 ### IPythonNotebook ###
 # Temporary data
 .ipynb_checkpoints/
-
-# Remove temporary text files
-*~

--- a/demos/demos.ipynb
+++ b/demos/demos.ipynb
@@ -1,28 +1,26 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# pypdb demos\n",
     "\n",
     "This is a set of basic examples of the usage and outputs of the various individual functions included in. There are generally three types of functions."
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Preamble"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%pylab inline\n",
     "from IPython.display import HTML\n",
@@ -37,326 +35,298 @@
     "\n",
     "%load_ext autoreload\n",
     "%autoreload 2"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Search functions that return lists of PDB IDs"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "found_pdbs = Query(27499440, \"PubmedIdQuery\").search()\n",
     "print(found_pdbs[:10])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Get a list of PDBs for a specific search term"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "found_pdbs = Query(\"ribosome\").search()\n",
     "print(found_pdbs[:10])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Search by PubMed ID Number"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "found_pdbs = Query(27499440, \"PubmedIdQuery\").search()\n",
     "print(found_pdbs[:10])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Search by source organism using NCBI TaxId"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "found_pdbs = Query('6239', 'TreeEntityQuery').search() #TaxID for C elegans\n",
     "print(found_pdbs[:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Search by a specific experimental method"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "found_pdbs = Query('SOLID-STATE NMR', query_type='ExpTypeQuery').search()\n",
     "print(found_pdbs[:10])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Search by protein structure similarity"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "found_pdbs = Query('2E8D', query_type=\"structure\").search()\n",
     "print(found_pdbs[:10])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Search by Author"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "found_pdbs = Query('Perutz, M.F.', query_type='AdvancedAuthorQuery').search()\n",
     "print(found_pdbs)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Search by organism"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "q = Query(\"Dictyostelium\", query_type=\"OrganismQuery\")\n",
     "print(q.search()[:10])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Information Search functions\n",
     "While the basic functions described in the previous section are useful for looking up and manipulating individual unique entries, these functions are intended to be more user-facing: they take search keywords and return lists of authors or dates"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Find papers for a given keyword"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "matching_papers = find_papers('crispr', max_results=10)\n",
     "print(list(matching_papers)[:10])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Functions that return information about single PDB IDs"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Get the full PDB file"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "pdb_file = get_pdb_file('4lza', filetype='cif', compression=False)\n",
     "print(pdb_file[:400])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Get a general description of the entry's metadata"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "all_info = get_info('4LZA')\n",
     "print(list(all_info.keys()))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Run a Sequence search\n",
     "\n",
     "Formerly using BLAST, this method now uses MMseqs2"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "q = Query(\"VLSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHFDLSHGSAQVKGHGKKVADALTAVAHVDDMPNAL\", \n",
     "          query_type=\"sequence\", \n",
     "          return_type=\"polymer_entity\")\n",
     "\n",
     "print(q.search())"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Search by PFAM number"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "pfam_info = Query(\"PF00008\", query_type=\"pfam\").search()\n",
     "print(pfam_info[:5])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   ],
    "outputs": [],
-   "source": []
+   "metadata": {}
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# New API for advanced search\n",
     "\n",
     "The old API will gradually migrate to use these functions"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from pypdb.clients.search.search_client import perform_search\n",
     "from pypdb.clients.search.search_client import ReturnType\n",
     "from pypdb.clients.search.operators import text_operators"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search for all entries that mention the word 'ribosome'"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "search_operator = text_operators.DefaultOperator(value=\"ribosome\")\n",
     "return_type = ReturnType.ENTRY\n",
@@ -364,21 +334,21 @@
     "results = perform_search(search_operator, return_type)\n",
     "\n",
     "print(results[:10])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search for polymers from 'Mus musculus'"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "search_operator = text_operators.ExactMatchOperator(value=\"Mus musculus\",\n",
     "                                                    attribute=\"rcsb_entity_source_organism.taxonomy_lineage.name\")\n",
@@ -387,21 +357,21 @@
     "results = perform_search(search_operator, return_type)\n",
     "\n",
     "print(results[:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search for non-polymers from 'Mus musculus' or 'Homo sapiens'"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "search_operator = text_operators.InOperator(values=[\"Mus musculus\", \"Homo sapiens\"],\n",
     "                                            attribute=\"rcsb_entity_source_organism.taxonomy_lineage.name\")\n",
@@ -409,21 +379,21 @@
     "\n",
     "results = perform_search(search_operator, return_type)\n",
     "print(results[:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search for polymer instances whose titles contain \"actin\" or \"binding\" or \"protein\""
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "search_operator = text_operators.ContainsWordsOperator(value=\"actin-binding protein\",\n",
     "                                            attribute=\"struct.title\")\n",
@@ -432,25 +402,25 @@
     "results = perform_search(search_operator, return_type)\n",
     "\n",
     "print(results[:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search for assemblies that contain the words \"actin binding protein\"\n",
     "(must be in that order).\n",
     "\n",
     "For example, \"actin-binding protein\" and \"actin binding protein\" will match,\n",
     "but \"protein binding actin\" will not."
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "search_operator = text_operators.ContainsPhraseOperator(value=\"actin-binding protein\",\n",
     "                                            attribute=\"struct.title\")\n",
@@ -459,21 +429,21 @@
     "results = perform_search(search_operator, return_type, verbosity=True)\n",
     "\n",
     "print(results[:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search for entries released in 2019 or later"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "search_operator = text_operators.ComparisonOperator(\n",
     "       value=\"2019-01-01T00:00:00Z\",\n",
@@ -484,21 +454,21 @@
     "results = perform_search(search_operator, return_type)\n",
     "\n",
     "print(results[:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search for entries released only in 2019"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "search_operator = text_operators.RangeOperator(\n",
     "    from_value=\"2019-01-01T00:00:00Z\",\n",
@@ -511,21 +481,21 @@
     "results = perform_search(search_operator, return_type)\n",
     "\n",
     "print(results[:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search by cell length and suppress query output"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from pypdb.clients.search.search_client import perform_search_with_graph, SearchService, ReturnType\n",
     "from pypdb.clients.search.operators import text_operators\n",
@@ -544,21 +514,21 @@
     ")\n",
     "\n",
     "print(results[:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search for structures under 4 angstroms of resolution"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "search_operator = text_operators.ComparisonOperator(\n",
     "           value=4,\n",
@@ -569,24 +539,24 @@
     "results = perform_search(search_operator, return_type)\n",
     "\n",
     "print(results[:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search for structures with a given attribute.\n",
     "\n",
     "(Admittedly every structure has a release date, but the same logic would\n",
     " apply for a more sparse RCSB attribute).\n"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "search_operator = text_operators.ExistsOperator(\n",
     "    attribute=\"rcsb_accession_info.initial_release_date\")\n",
@@ -595,21 +565,21 @@
     "results = perform_search(search_operator, return_type)\n",
     "\n",
     "print(results[:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Search for 'Mus musculus' or 'Homo sapiens' structures after 2019 using graph search\n"
-   ]
+   ],
+   "metadata": {},
+   "attachments": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from pypdb.clients.search.search_client import perform_search_with_graph\n",
     "from pypdb.clients.search.search_client import ReturnType\n",
@@ -650,42 +620,9 @@
     "  query_object=is_under_4A_and_human_or_mus_group,\n",
     "  return_type=return_type)\n",
     "print(\"\\n\", results[:10]) # Huzzah"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   ],
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/pypdb/clients/data/graphql/graphql.py
+++ b/pypdb/clients/data/graphql/graphql.py
@@ -4,6 +4,8 @@ For the differences between the GraphQL and RESTful searches, see:
 https://data.rcsb.org/index.html#gql-vs-rest
 """
 
+import requests
+import  warnings
 from typing import Any  # DO NOT APPROVE: fix this to actual type
 
 RSCB_GRAPHQL_URL = "https://data.rcsb.org/graphql?query="
@@ -23,4 +25,12 @@ def search_graphql(graphql_json_query: str) -> Any:
             matter. e.g. "{entry(entry_id:"4HHB"){exptl{method}}}"
     """
 
-    raise UnimplementedError("Currently unimplemented")
+    response = requests.post(url=RSCB_GRAPHQL_URL,
+                             json=graphql_json_query)
+
+    if not response.ok:
+        warnings.warn(f"It appears request failed with: {response.text}")
+        response.raise_for_status()
+
+
+    return response.json()

--- a/pypdb/clients/data/graphql/test_graphql.py
+++ b/pypdb/clients/data/graphql/test_graphql.py
@@ -1,1 +1,25 @@
-# Currently unimplemented
+"""Unit tests for RCSB DATA API Python wrapper."""
+import unittest
+from unittest import mock
+import requests
+
+from pypdb.clients.data.graphql import graphql
+
+class TestGraphQL(unittest.TestCase):
+    @mock.patch.object(requests, "post")
+    def test_simple_search(self, mock_post):
+        json_query = {'query': '{ entry(entry_id: "4HHB"){struct {title}} }'}
+        expected_return_json_as_dict = {'data': {'entry': {'struct': {'title': 'THE CRYSTAL STRUCTURE OF HUMAN DEOXYHAEMOGLOBIN AT 1.74 ANGSTROMS RESOLUTION'}}}}
+
+        mock_response = mock.create_autospec(requests.Response, instance=True)
+        mock_response.json.return_value = expected_return_json_as_dict
+        mock_post.return_value = mock_response
+
+        results = graphql.search_graphql(json_query)
+
+        mock_post.assert_called_once_with(url=graphql.RSCB_GRAPHQL_URL, json=json_query)
+        self.assertEqual(results, expected_return_json_as_dict)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pypdb/clients/search/EXAMPLES.md
+++ b/pypdb/clients/search/EXAMPLES.md
@@ -12,7 +12,7 @@ you are querying the RCSB Text Search Service (`all
 operators within `text_operators.py` should be supported.
 
 For a list of RCSB attributes associated with structures you can search, see
-[RCSB's List of Attributes to Search](http://search.rcsb.org/search-attributes.html).
+[RCSB's List of Structure Attributes to Search](https://search.rcsb.org/structure-search-attributes.html) and [RCSB's List of Chemical Attributes to Search](https://search.rcsb.org/chemical-search-attributes.html)
 Note that not every structure will have every attribute.
 
 Two querying functions are currently supported by PyPDB:

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ modules_list = [
     "pypdb.clients.search",
     "pypdb.clients.search.operators",
     "pypdb.clients.data",
+    "pypdb.clients.data.graphql",
     "pypdb.clients.fasta",
     "pypdb.clients.pdb",
 ]


### PR DESCRIPTION
Hello, I intend this to be the first in a serious of contributions that would get the data submodule functional. This is sort of an early PR to make sure I'm moving in a direction that would be compatible with your vision. (And to make sure I did not break any  installation recipes).

Briefly:
- minor fixes including updating some dead RSCB links, clearing out the empty cells in the demo, and removing a redundant entry in .gitignore (and adding a .vscode entry because I use vscode as a code editor)
- added extremely basic functionality to graphql, where passing in json arguments as a dict returns the results as a dict. Updated `test_graphql.py` with a simple test.
- added `pypdb.clients.data.graphql` to `modules_list` in `setup.py`
- `setup.py` didn't work for me, and I realized an `__init__.py` was missing in `pypdb/clients/search/operators/`. I'm not sure how the installation with `pip` worked before this, so I may have missed something.