### PR TITLE
Remove pandas usage and dependency.

### DIFF
--- a/pypdb/clients/data/data_types.py
+++ b/pypdb/clients/data/data_types.py
@@ -18,7 +18,6 @@ Namely:
 - DrugBank integrated data
 """
 from dataclasses import dataclass, field
-import pandas as pd
 from enum import Enum
 
 #TODO: handle batch requests
@@ -162,9 +161,9 @@ class DataFetcher:
         if len(self.response['data'][self.data_type.value]) != len(self.id):
             print("WARNING: one or more IDs not found in the PDB.")
 
-    def return_data_as_pandas_df(self):
+    def return_data_as_df_dict(self):
         """
-        Return the fetched data as a pandas dataframe.
+        Return the fetched data as a dict usable by pandas or polars.
         """
         if not self.response:
             return None
@@ -190,4 +189,4 @@ class DataFetcher:
                         curr_dict[new_key] = val
             data_flat[id] = curr_dict
 
-        return pd.DataFrame.from_dict(data_flat, orient='index')
+        return data_flat

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=modules_list,  # same as 'name'
     py_modules=modules_list,
     version='2.03',
-    install_requires=['requests', 'pandas'],
+    install_requires=['requests'],
     description='A Python wrapper for the RCSB Protein Data Bank (PDB) API',
     author='William Gilpin',
     author_email='firstnamelastname@gmail.com',


### PR DESCRIPTION
pypdb depends on pandas which is a fairly big package for one minor use. This change allows to remove this dependency and while essentially keeping the same feature.