### PR TITLE
Add JSON Content-Type header to request

### DIFF
--- a/pypdb/pypdb.py
+++ b/pypdb/pypdb.py
@@ -297,6 +297,7 @@ class Query(object):
         query_text = json.dumps(self.scan_params, indent=4)
         response = http_requests.request_limited(self.url,
                                                  rtype="POST",
+                                                 headers={"Content-Type": "application/json"},
                                                  data=query_text)
 
         if response is None or response.status_code != 200:


### PR DESCRIPTION
RCSB sequence search is currently returning a 415 status code for this library due to the lack of Content-Type header in the request. This PR adds the required header.

Can be verified with a simple sequence query:

```python
import pypdb
query = pypdb.Query('SLDRSSCFTGSLDSIRAQSGLGCNSFRY', query_type='sequence', return_type='entry')
print(query.search())
```